### PR TITLE
fix typo on the impressiontime field in the impressions.avro file

### DIFF
--- a/src/main/resources/impressions.avro
+++ b/src/main/resources/impressions.avro
@@ -3,7 +3,7 @@
         "name": "impressions",
         "type": "record",
         "fields": [
-                {"name": "impresssiontime", "type": {
+                {"name": "impressiontime", "type": {
                     "type": "long",
                     "format_as_time" : "unix_long",
                     "arg.properties": {


### PR DESCRIPTION
The "impression time" field had an extra 's' in the name in the AVRO file.  This caused me to run into a

`No column with the provided key column name in the WITH clause, IMPRESSSIONTIME, exists in the defined schema.`

error when I copied it in one place and typed it in another place in KSQL.